### PR TITLE
Iris update2

### DIFF
--- a/miniTidyPy/my_spread.py
+++ b/miniTidyPy/my_spread.py
@@ -46,10 +46,6 @@ def my_spread(df, key, value):
         if col != key and col != value: # the preserved columns
             struc[col] = []
             preserved.append(col)
-            
-    # if no preserved columns, raise an error
-    if len(preserved) == 0:
-        raise ValueError('Dataframe without unique identifiers')
 
     # add key columns and value to the end
     for keyname in keys:

--- a/miniTidyPy/my_spread.py
+++ b/miniTidyPy/my_spread.py
@@ -1,5 +1,4 @@
 # This is the script for function my_spread
-# Function left black at this point for further contributions
 
 # import packages
 import pandas as pd
@@ -47,10 +46,25 @@ def my_spread(df, key, value):
         if col != key and col != value: # the preserved columns
             struc[col] = []
             preserved.append(col)
+            
+    # if no preserved columns, raise an error
+    if len(preserved) == 0:
+        raise ValueError('Dataframe without unique identifiers')
 
     # add key columns and value to the end
     for keyname in keys:
         struc[keyname] = []
+        
+    # check if the preserved columns and the key columns form unique identifiers
+    check_id = []
+    for i in range(df.shape[0]):
+        idf = ""
+        for col in preserved:  # add preserved column value to the string
+            idf = idf + str(df[col][i]) + " "
+        idf = idf + str(df[key][i]) # add key column value to the string
+        check_id.append(idf)
+    if len(check_id) != len(set(check_id)):
+        raise ValueError('Dataframe without unique identifiers')
 
     # turn the values in the preserved columns into a list of strings
     pre_combos = []
@@ -82,4 +96,4 @@ def my_spread(df, key, value):
         for colname in list(struc):
             struc[colname].append(combo_dic[c][colname])
 
-    return pd.DataFrame(struc)
+    return pd.DataFrame(struc) 

--- a/miniTidyPy/test/test_my_spread.py
+++ b/miniTidyPy/test/test_my_spread.py
@@ -78,4 +78,5 @@ def test_my_spread_na():
     assert d0_test.equals(output_na), "key column contains NaN"
 
     # when the whole dataframe contains NaN
-    assert miniTidyPy.my_spread(all_na, key = 'a', value = 'b').equals(pd.DataFrame({}))
+    with pytest.raises(ValueError):
+        miniTidyPy.my_spread(all_na, key = 'a', value = 'b')


### PR DESCRIPTION
1. Modify `my_spread`:
- Raise error when only have key and value column and key column is not unique
- Raise error when no unique identifiers

2. Modify `test_my_spread` to match the error raise.